### PR TITLE
Fixed mistake in default store_args

### DIFF
--- a/lib/Catalyst/Controller/SimpleCAS.pm
+++ b/lib/Catalyst/Controller/SimpleCAS.pm
@@ -37,7 +37,7 @@ has store_path => ( is => 'ro', lazy => 1, default => sub {
 has store_args => ( is => 'ro', isa => 'HashRef', lazy => 1, default => sub {
   my $self = shift;
   return {
-    store_path => $self->store_path,
+    store_dir => $self->store_path,
   };
 });
 


### PR DESCRIPTION
Fixing stupid typo I introduced on restructure the args of SimpleCAS
as in giving store_path not store_dir as default store_args, which
lets to a missing required arguments error on file storage usage.
