### PR TITLE
DBIC Storage

### DIFF
--- a/lib/Catalyst/Controller/SimpleCAS.pm
+++ b/lib/Catalyst/Controller/SimpleCAS.pm
@@ -23,24 +23,38 @@ use JSON;
 use MIME::Base64;
 use String::Random;
 
+has store_class => ( is => 'ro', default => sub {
+  '+File'
+});
 
-has 'store_class', is => 'ro', default => sub{'Catalyst::Controller::SimpleCAS::Store::File'};
-has 'store_path', is => 'ro', lazy => 1, default => sub {
+has store_path => ( is => 'ro', lazy => 1, default => sub {
   my $self = shift;
   my $c = $self->_app;
   # Default Cas Store path if none was supplied in the config:
   return dir( Catalyst::Utils::home($c), 'cas_store' )->stringify;
-};
+});
 
-has 'Store' => (
+has store_args => ( is => 'ro', isa => 'HashRef', lazy => 1, default => sub {
+  my $self = shift;
+  return {
+    store_dir => $self->store_path,
+  };
+});
+
+has Store => (
+  does => 'Catalyst::Controller::SimpleCAS::Store',
   is => 'ro',
   lazy => 1,
   default => sub {
     my $self = shift;
     my $class = $self->store_class;
+    if ($class =~ m/^\+([\w:]+)/) {
+      $class = 'Catalyst::Controller::SimpleCAS::Store::'.$1;
+    }
     Module::Runtime::require_module($class);
     return $class->new(
-      store_dir => $self->store_path
+      simplecas => $self,
+      %{$self->store_args},
     );
   }
 );
@@ -344,6 +358,28 @@ sub _json_response {
   }
 }
 
+# Moved checksum functions to SimpleCAS main class, as it should be
+# not related to the Store - GETTY
+sub file_checksum {
+  my $self = shift;
+  my $file = shift;
+  
+  my $FH = IO::File->new();
+  $FH->open('< ' . $file) or die "$! : $file\n";
+  $FH->binmode;
+
+  my $sha1 = Digest::SHA1->new->addfile($FH)->hexdigest;
+  $FH->close;
+  return $sha1;
+}
+
+sub calculate_checksum {
+  my $self = shift;
+  my $data = shift;
+  
+  my $sha1 = Digest::SHA1->new->add($data)->hexdigest;
+  return $sha1;
+}
 
 1;
 
@@ -488,6 +524,10 @@ Not usually called directly
 =head2 uri_find_Content
 
 Not usually called directly
+
+=head2 calculate_checksum
+
+=head2 file_checksum
 
 =head1 SEE ALSO
 

--- a/lib/Catalyst/Controller/SimpleCAS.pm
+++ b/lib/Catalyst/Controller/SimpleCAS.pm
@@ -142,14 +142,14 @@ sub upload_image :Chained('base') :Args {
   my ($self, $c, $maxwidth, $maxheight) = @_;
 
   my $upload = $c->req->upload('Filedata') or die "no upload object";
-  
+
   my ($type,$subtype) = split(/\//,$upload->type);
   
   my $resized = \0;
   my $shrunk = \0;
   
   my ($checksum,$width,$height,$orig_width,$orig_height);
-  
+
   if($self->_is_image_resize_available) {
     # When Image::Resize is available:
     ($checksum,$width,$height,$resized,$orig_width,$orig_height) 
@@ -257,6 +257,7 @@ sub add_size_info_image :Private {
   my $shrunk = \0;
 
   my ($width,$height) = $self->Store->image_size($checksum);
+
   my ($orig_width,$orig_height) = ($width,$height);
   if (defined $maxwidth) {
     

--- a/lib/Catalyst/Controller/SimpleCAS/Store.pm
+++ b/lib/Catalyst/Controller/SimpleCAS/Store.pm
@@ -8,6 +8,7 @@ use IO::File;
 use MIME::Base64;
 use File::MimeInfo::Magic;
 use Image::Size;
+use Email::MIME;
 use IO::All;
 
 has simplecas => (

--- a/lib/Catalyst/Controller/SimpleCAS/Store.pm
+++ b/lib/Catalyst/Controller/SimpleCAS/Store.pm
@@ -6,6 +6,7 @@ use Moose::Role;
 use Digest::SHA1;
 use IO::File;
 use MIME::Base64;
+use Try::Tiny;
 use File::MimeInfo::Magic;
 use Image::Size;
 use Email::MIME;

--- a/lib/Catalyst/Controller/SimpleCAS/Store.pm
+++ b/lib/Catalyst/Controller/SimpleCAS/Store.pm
@@ -38,12 +38,12 @@ sub add_content_base64 {
 sub add_content_file {
   my $self = shift;
   my $file = shift;
-  
+
   my $checksum = $self->file_checksum($file);
 
   return $checksum if ($self->content_exists($checksum));
-  
-  return $self->add_content(scalar(io($file)->slurp_raw));
+
+  return $self->add_content(scalar(io($file)->slurp));
 }
 
 sub add_content_file_mv {

--- a/lib/Catalyst/Controller/SimpleCAS/Store.pm
+++ b/lib/Catalyst/Controller/SimpleCAS/Store.pm
@@ -38,9 +38,10 @@ sub add_content_file {
   my $file = shift;
   
   my $checksum = $self->file_checksum($file);
+
   return $checksum if ($self->content_exists($checksum));
   
-  return $self->add_content(scalar(io($file)->slurp));
+  return $self->add_content(scalar(io($file)->slurp_raw));
 }
 
 sub add_content_file_mv {
@@ -83,10 +84,10 @@ sub content_mimetype {
     my ($type) = split(/\s*\;\s*/,$MIME->content_type);
     return $type;
   }
-  
+
   # Otherwise, guess the mimetype from the file on disk
   my $file = $self->checksum_to_path($checksum);
-  
+
   return undef unless ( -f $file );
   return mimetype($file);
 }
@@ -103,7 +104,7 @@ sub content_size {
 sub fetch_content_fh {
   my $self = shift;
   my $checksum = shift;
-  
+
   my $file = $self->checksum_to_path($checksum);
   return undef unless ( -f $file);
   

--- a/lib/Catalyst/Controller/SimpleCAS/Store.pm
+++ b/lib/Catalyst/Controller/SimpleCAS/Store.pm
@@ -1,0 +1,183 @@
+package Catalyst::Controller::SimpleCAS::Store;
+
+use warnings;
+use Moose::Role;
+
+use Digest::SHA1;
+use IO::File;
+use MIME::Base64;
+use File::MimeInfo::Magic;
+use Image::Size;
+use IO::All;
+
+has simplecas => (
+  isa => 'Catalyst::Controller::SimpleCAS',
+  is => 'ro',
+  required => 1,
+  handles => [qw(
+    file_checksum
+    calculate_checksum
+  )],
+);
+
+requires qw(
+  content_exists
+  fetch_content
+  add_content
+  checksum_to_path
+);
+
+sub add_content_base64 {
+  my $self = shift;
+  my $data = decode_base64(shift) or die "Error decoding base64 data. $@";
+  return $self->add_content($data);
+}
+
+sub add_content_file {
+  my $self = shift;
+  my $file = shift;
+  
+  my $checksum = $self->file_checksum($file);
+  return $checksum if ($self->content_exists($checksum));
+  
+  return $self->add_content(scalar(io($file)->slurp));
+}
+
+sub add_content_file_mv {
+  my $self = shift;
+  my $file = shift;
+
+  my $result = $self->add_content_file($file);
+
+  die "SimpleCAS: Failed to move file '$file' into storage" unless $result;
+
+  unlink $file;
+  
+  return $result;
+}
+
+sub image_size {
+  my $self = shift;
+  my $checksum = shift;
+  
+  my $content_type = $self->content_mimetype($checksum) or return undef;
+  my ($mime_type,$mime_subtype) = split(/\//,$content_type);
+  return undef unless ($mime_type eq 'image');
+  
+  my ($width,$height) = imgsize($self->checksum_to_path($checksum)) or return undef;
+  return ($width,$height);
+}
+
+sub content_mimetype {
+  my $self = shift;
+  my $checksum = shift;
+  
+  # See if this is an actual MIME file with a defined Content-Type:
+  my $MIME = try{
+    my $fh = $self->fetch_content_fh($checksum);
+    # only read the begining of the file, enough to make it past the Content-Type header:
+    my $buf; $fh->read($buf,1024); $fh->close;
+    return Email::MIME->new($buf);
+  };
+  if($MIME && $MIME->content_type) {
+    my ($type) = split(/\s*\;\s*/,$MIME->content_type);
+    return $type;
+  }
+  
+  # Otherwise, guess the mimetype from the file on disk
+  my $file = $self->checksum_to_path($checksum);
+  
+  return undef unless ( -f $file );
+  return mimetype($file);
+}
+
+sub content_size {
+  my $self = shift;
+  my $checksum = shift;
+  
+  my $file = $self->checksum_to_path($checksum);
+  
+  return file($file)->stat->size;
+}
+
+sub fetch_content_fh {
+  my $self = shift;
+  my $checksum = shift;
+  
+  my $file = $self->checksum_to_path($checksum);
+  return undef unless ( -f $file);
+  
+  my $fh = IO::File->new();
+  $fh->open('< ' . $file) or die "Failed to open $file for reading.";
+  
+  return $fh;
+}
+
+1;
+
+=head1 NAME
+
+Catalyst::Controller::SimpleCAS::Store - Base Role for all SimpleCAS Store
+
+=head1 SYNOPSIS
+
+=head1 DESCRIPTION
+
+Used as role for all storages of SimpleCAS.
+
+=head1 METHODS
+
+=head2 add_content
+
+=head2 add_content_base64
+
+=head2 add_content_file
+
+=head2 add_content_file_mv
+
+=head2 calculate_checksum
+
+=head2 checksum_to_path
+
+=head2 content_exists
+
+=head2 content_mimetype
+
+=head2 content_size
+
+=head2 fetch_content
+
+=head2 fetch_content_fh
+
+=head2 file_checksum
+
+=head2 image_size
+
+=head2 init_store_dir
+
+=head2 split_checksum
+
+=head1 SEE ALSO
+
+=over
+
+=item *
+
+L<Catalyst::Controller::SimpleCAS>
+
+=back
+
+=head1 AUTHOR
+
+Henry Van Styn <vanstyn@cpan.org>
+
+Torsten Raudssus <torsten@raudss.us>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2014 by IntelliTree Solutions llc.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/lib/Catalyst/Controller/SimpleCAS/Store/DBIC.pm
+++ b/lib/Catalyst/Controller/SimpleCAS/Store/DBIC.pm
@@ -1,0 +1,201 @@
+package Catalyst::Controller::SimpleCAS::Store::DBIC;
+
+use warnings;
+use Moose;
+
+with qw(
+  Catalyst::Controller::SimpleCAS::Store
+);
+
+use File::MimeInfo::Magic;
+use Image::Size;
+use Digest::SHA1;
+use IO::File;
+use Data::Dumper;
+use MIME::Base64;
+use Try::Tiny;
+use Path::Class qw( file dir );
+
+use IO::All;
+
+use bytes;
+
+has 'model' => ( is => 'ro', isa => 'Str', required => 1 );
+has 'tempdir' => ( is => 'ro', isa => 'Str', lazy => 1, default => sub {
+  my $self = shift;
+  return dir( Catalyst::Utils::class2tempdir($self->resultset->result_class), 'simplecas' )->stringify;
+});
+
+sub resultset {
+  my ( $self ) = @_;
+  $self->simplecas->_app->model($self->model);
+}
+
+sub get_result_by_checksum {
+  my ( $self, $checksum ) = @_;
+  return $self->resultset->find({
+    checksum => $checksum,
+  });
+}
+
+sub add_content {
+  my ( $self, $data ) = @_;
+  my $checksum = $self->calculate_checksum($data);
+  return $checksum if ($self->content_exists($checksum));
+  my $size = length($data);
+  my $result = $self->resultset->create({
+    content => $data,
+    checksum => $self->calculate_checksum($data),
+    size => $size,
+  });
+  die "Unable to store data of $size bytes in Storage" unless $result;
+  return $result->checksum;
+}
+
+sub checksum_to_path {
+  my ( $self, $checksum ) = @_;
+  my @parts = unpack("(A5)*", $checksum);
+  my $filename = pop @parts;
+  my $dir = join("/",$self->tempdir,@parts);
+  my $fullname = join("/",$dir,$filename);
+  return $fullname if io($fullname)->exists; 
+  io($dir)->mkpath;
+  my $entry = $self->get_result_by_checksum($checksum);
+  io($fullname)->print($entry->content);
+  return $fullname;
+}
+
+sub fetch_content {
+  my ( $self, $checksum ) = @_;
+  my $entry = $self->get_result_by_checksum($checksum);
+  return "" unless $entry;
+  return $entry->content;
+}
+
+sub content_exists {
+  my ( $self, $checksum ) = @_;
+  return $self->get_result_by_checksum($checksum) ? 1 : 0;
+}
+
+around content_mimetype => sub {
+  my $orig = shift;
+  my $self = shift;
+  my $checksum = shift;
+  my $result = $self->get_result_by_checksum($checksum);
+  return undef unless $result;
+  return $result->mimetype if defined $result->mimetype;
+  my $mimetype = $self->$orig($checksum) || '';
+  $result->mimetype($mimetype);
+  $result->update;
+  return $mimetype;
+};
+
+around image_size => sub {
+  my $orig = shift;
+  my $self = shift;
+  my $checksum = shift;
+  my $result = $self->get_result_by_checksum($checksum);
+  return unless $result;
+  if (defined $result->image_width) {
+    return undef unless $result->image_width;
+    return ( $result->image_width, $result->image_height );
+  }
+  my ( $width, $height ) = $self->$orig($checksum);
+  $width = 0 unless $width;
+  $height = 0 unless $height;
+  $result->image_width($width);
+  $result->image_height($height);
+  $result->update;
+  return undef unless $width;
+  return ( $width, $height );
+};
+
+sub content_size {
+  my ( $self, $checksum ) = @_;
+  my $result = $self->get_result_by_checksum($checksum);
+  return $result ? $result->size : 0;
+}
+
+#### --------------------- ####
+
+no Moose;
+#__PACKAGE__->meta->make_immutable;
+1;
+
+__END__
+
+=head1 NAME
+
+Catalyst::Controller::SimpleCAS::Store::DBIC - DBIx::Class Store for SimpleCAS
+
+=head1 SYNOPSIS
+
+
+
+=head1 DESCRIPTION
+
+
+
+=head1 ATTRIBUTES
+
+=head2 resultset
+
+The actual L<DBIx::Class> ResultSet that should be used for all storage
+activity.
+
+=head1 METHODS
+
+=head2 add_content
+
+=head2 add_content_base64
+
+=head2 add_content_file
+
+=head2 add_content_file_mv
+
+=head2 calculate_checksum
+
+=head2 checksum_to_path
+
+=head2 content_exists
+
+=head2 content_mimetype
+
+=head2 content_size
+
+=head2 fetch_content
+
+=head2 fetch_content_fh
+
+=head2 file_checksum
+
+=head2 image_size
+
+=head2 init_store_dir
+
+=head2 split_checksum
+
+=head2 get_result_by_checksum
+
+=head1 SEE ALSO
+
+=over
+
+=item *
+
+L<Catalyst::Controller::SimpleCAS>
+
+=back
+
+=head1 AUTHOR
+
+Torsten Raudssus <torsten@raudss.us>
+
+=head1 COPYRIGHT AND LICENSE
+
+This software is copyright (c) 2014 by IntelliTree Solutions llc.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -12,7 +12,8 @@ use_ok('Catalyst::Controller::SimpleCAS');
 use_ok('Catalyst::Controller::SimpleCAS::Role::TextTranscode');
 use_ok('Catalyst::Controller::SimpleCAS::Content');
 use_ok('Catalyst::Controller::SimpleCAS::MimeUriResolver');
+use_ok('Catalyst::Controller::SimpleCAS::Store');
+use_ok('Catalyst::Controller::SimpleCAS::Store::DBIC');
 use_ok('Catalyst::Controller::SimpleCAS::Store::File');
-
 
 done_testing;

--- a/t/99_podspelling.t
+++ b/t/99_podspelling.t
@@ -12,7 +12,7 @@ add_stopwords(qw(
     SimpleCAS CAS DBIC sha MHTML Addl checksum fh filelink imglink
     mimetype deduplicates resize resized Cas refactored Filedata
     RapidApp IntelliTree Styn llc functionalities ExtJS SimmpleCAS
-    jsonData
+    jsonData Raudssus ResultSet Torsten resultset
 ));
 
 set_spell_cmd('aspell list -l en');


### PR DESCRIPTION
Splitted out a Store Moose::Role for be used for all Store classes.
With this then I implemented a storage class for storing the content
in a table in the database. This can be given as DBIC Model from
Catalyst yet, but should have several options later on. Also the
column names are right now fixed to be like the actual API of the
class, but will be configurable in some next version. More
documentation to come.
