### PR TITLE
Fix Store::File backend on Win32 Strawberry perl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Catalyst-Controller-SimpleCAS*
 .build/
+t/tmp

--- a/lib/Catalyst/Controller/SimpleCAS.pm
+++ b/lib/Catalyst/Controller/SimpleCAS.pm
@@ -56,7 +56,11 @@ has Store => (
       simplecas => $self,
       %{$self->store_args},
     );
-  }
+  },
+  handles => [qw(
+    file_checksum
+    calculate_checksum
+  )],
 );
 
 #has 'fetch_url_path', is => 'ro', isa => 'Str', default => '/simplecas/fetch_content/';
@@ -357,29 +361,6 @@ sub _json_response {
     $c->res->content_type('application/json; charset=utf-8');
     $c->res->body( $c->stash->{jsonData} );
   }
-}
-
-# Moved checksum functions to SimpleCAS main class, as it should be
-# not related to the Store - GETTY
-sub file_checksum {
-  my $self = shift;
-  my $file = shift;
-  
-  my $FH = IO::File->new();
-  $FH->open('< ' . $file) or die "$! : $file\n";
-  $FH->binmode;
-
-  my $sha1 = Digest::SHA1->new->addfile($FH)->hexdigest;
-  $FH->close;
-  return $sha1;
-}
-
-sub calculate_checksum {
-  my $self = shift;
-  my $data = shift;
-  
-  my $sha1 = Digest::SHA1->new->add($data)->hexdigest;
-  return $sha1;
 }
 
 1;

--- a/lib/Catalyst/Controller/SimpleCAS/Store.pm
+++ b/lib/Catalyst/Controller/SimpleCAS/Store.pm
@@ -13,16 +13,6 @@ use Email::MIME;
 use IO::All;
 use Path::Class qw( file dir );
 
-has simplecas => (
-  isa => 'Catalyst::Controller::SimpleCAS',
-  is => 'ro',
-  required => 1,
-  handles => [qw(
-    file_checksum
-    calculate_checksum
-  )],
-);
-
 requires qw(
   content_exists
   fetch_content
@@ -118,6 +108,28 @@ sub fetch_content_fh {
   $fh->open('< ' . $file) or die "Failed to open $file for reading.";
   
   return $fh;
+}
+
+# All stores should use SHA-1, in order to be able to swap Store modules later on.
+sub file_checksum {
+  my $self = shift;
+  my $file = shift;
+  
+  my $FH = IO::File->new();
+  $FH->open('< ' . $file) or die "$! : $file\n";
+  $FH->binmode;
+
+  my $sha1 = Digest::SHA1->new->addfile($FH)->hexdigest;
+  $FH->close;
+  return $sha1;
+}
+
+sub calculate_checksum {
+  my $self = shift;
+  my $data = shift;
+  
+  my $sha1 = Digest::SHA1->new->add($data)->hexdigest;
+  return $sha1;
 }
 
 1;

--- a/t/10_store_file.t
+++ b/t/10_store_file.t
@@ -16,9 +16,8 @@ use_ok('Catalyst::Controller::SimpleCAS::Store::File');
 
 my $cas_dir= catdir( $Bin, 'tmp', 'cas' );
 
--d $cas_dir or mkdir $cas_dir or die "Can't create tmpdir $cas_dir";
 remove_tree($cas_dir) if -d $cas_dir;
-make_path($cas_dir);
+make_path($cas_dir) or die "Can't create tmpdir $cas_dir";
 
 my $file_cas= new_ok 'Catalyst::Controller::SimpleCAS::Store::File',
 	[ store_dir => $cas_dir ], "create CAS instance on $cas_dir";

--- a/t/10_store_file.t
+++ b/t/10_store_file.t
@@ -1,0 +1,41 @@
+# -*- perl -*-
+
+use strict;
+use warnings;
+use FindBin '$Bin';
+use File::Spec::Functions 'catfile', 'catdir', 'tmpdir';
+use File::Path 'make_path', 'remove_tree';
+use lib "$Bin/lib";
+
+use Test::More;
+use Test::Exception;
+
+use_ok('Catalyst::Controller::SimpleCAS::Store::File');
+
+# Create a CAS structure within the test directory here.
+
+my $cas_dir= catdir( $Bin, 'tmp', 'cas' );
+
+-d $cas_dir or mkdir $cas_dir or die "Can't create tmpdir $cas_dir";
+remove_tree($cas_dir) if -d $cas_dir;
+make_path($cas_dir);
+
+my $file_cas= new_ok 'Catalyst::Controller::SimpleCAS::Store::File',
+	[ store_dir => $cas_dir ], "create CAS instance on $cas_dir";
+
+# Write a dummy file to the system temp path to simulate what Catalyst would
+# use for a file upload.
+my $origin_file= catfile(tmpdir(), 'incoming.txt');
+{
+	open my $fh, '>:raw', $origin_file or die "open: $!";
+	print $fh "This file simulates a Catalyst upload to the temp directory\n";
+	close $fh;
+}
+
+my $cksum= $file_cas->add_content_file_mv($origin_file);
+is( $cksum, '437c659b4c0fea1304edea50c2cdd420f8c0f6f6', 'file hashed correctly' );
+
+ok( -e $file_cas->checksum_to_path($cksum), 'new file exists' );
+ok( !-e $origin_file, 'old file removed' );
+
+done_testing;


### PR DESCRIPTION
This set of changes fixes the file-based backend for running on Strawberry perl on Windows.  It probably also fixes ActiveState on Windows.  (cygwin perl wasn't broken)  I added a testcase for this specific scenario.

The version number / changelog still needs bumped before publishing.  I can do that if you like.
